### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ public/fonts
 dist/
 lib/
 .vscode/
+docs/


### PR DESCRIPTION
Added doc directory to gitignore, adding docs folder, which is generated, in each release or merge, makes really difficult to track the changes, and makes the size of git unnecessarily big. If you use github to publish live version/documentation, maybe it's better to create separate repo for that purpose. Since last week, team feature is free in github, you can create a team called "React-Design-Editor" then move this repo there as main repo and add additional repo for preview site. I can help you if you want to set it up.

Btw, it's really very nice code, great job. Thanks a lot for sharing.