### PR TITLE
feat: add new description to image save icon in image map header toolbar

### DIFF
--- a/src/editors/imagemap/ImageMapHeaderToolbar.js
+++ b/src/editors/imagemap/ImageMapHeaderToolbar.js
@@ -140,7 +140,7 @@ class ImageMapHeaderToolbar extends Component {
 						disabled={isCropping}
 						onClick={() => canvasRef.handler?.saveImage()}
 						icon="image"
-						tooltipTitle={i18n.t('action.image-save')}
+						tooltipTitle={i18n.t('action.canvas-save')}
 					/>
 					<CommonButton
 						className="rde-action-btn"

--- a/src/locales/locale.constant.json
+++ b/src/locales/locale.constant.json
@@ -122,6 +122,7 @@
 		"crop-save": "Save crop image",
 		"crop-cancel": "Cancel crop image",
 		"image-save": "Save Image",
+		"canvas-save": "Save Canvas",
 		"clone": "Clone",
 		"delete": "Delete",
 		"save": "Save",


### PR DESCRIPTION
Based on the issue that I opened [ #250 ], where I said that the save image icon in the toolbar was confusing, as it referred to a specific canvas of the image, I decided to make this contribution where I added a new description for this button, following the library's tips "i18next" used in the project.

![image](https://github.com/salgum1114/react-design-editor/assets/80059604/2e97dedd-46ca-49a4-986b-2f6fb71e86ae)
