### PR TITLE
fix: show error message when uploaded file exceeds size limit

### DIFF
--- a/src/components/common/FileUpload.js
+++ b/src/components/common/FileUpload.js
@@ -60,7 +60,8 @@ class FileUpload extends Component {
 			beforeUpload: file => {
 				const isLimit = file.size / 1024 / 1024 < limit;
 				if (!isLimit) {
-					return false;
+					message.error(`Limited to ${limit}MB or less`);
+					return Upload.LIST_IGNORE;
 				}
 				this.setState({
 					fileList: [file],


### PR DESCRIPTION
Fixes #244

## Problem
Uploading an image larger than the allowed size limit did not display an error message in the UI, and caused confusion.

## Solution
Added `message.error` inside the `beforeUpload` handler to properly notify users when the file exceeds the size limit.

## Result
- Error message now appears correctly
- Prevents oversized file upload
- Improves user experience